### PR TITLE
Add TruthLayer to dApps directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@
 
 ## dApps directory
 
+- [TruthLayer](https://github.com/miraekims/Truthlayer) — Open-source Web3 reputation layer for Crypto Twitter. Multi-chain (ETH, SOL, Base, Arbitrum, BNB) wallet verification through SIWE/SIWS. Chrome extension + Postgres-backed identity graph.
+
+
 ### AAA Web3 Games
 - [Delysium](https://www.delysium.com/) - Delysium is a high-quality web3 game that you can actually play.
 - [Heroic Story](https://www.heroicstory.com/) - Discover an exciting tabletop role-playing game that offers 12 unique character classes and a vast, ever-expanding world to explore for free.


### PR DESCRIPTION
Hey Starton,

Adding TruthLayer to your awesome list. It's an open-source Chrome 
extension that adds wallet-verification badges next to every @handle 
on X (Twitter), letting users see if a KOL actually holds tokens 
they're shilling.

**Why it fits:**
- ✓ Open source (source-available license, MIT-compatible terms)
- ✓ Multi-chain: Ethereum, Solana, Base, Arbitrum, BNB Chain
- ✓ Production-ready: SIWE/SIWS signature verification, 
  Postgres-backed identity graph, Docker-ready API
- ✓ Active development (just shipped v0.1.0, regular releases)
- ✓ Zero ads, zero token, free deployment

**Repository:** https://github.com/miraekims/Truthlayer

Happy to adjust formatting if needed. Thanks for maintaining this list!
